### PR TITLE
Fixes for MQA

### DIFF
--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -541,6 +541,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         self.allreduce_embedding_grads(args)
         timers('backward-embedding-all-reduce').stop()
 
+        # All-reduce key-value grads if needed.
+        if args.attention_head_type == "multiquery":
+            timers('backward-key-value-all-reduce').start()
+            self.allreduce_key_value_grads(args)
+            timers('backward-key-value-all-reduce').stop()
+
         # Reduce-scatter setup.
         timers('backward-params-all-reduce').start()
         data_parallel_rank = mpu.get_data_parallel_rank()

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -267,18 +267,28 @@ class MegatronOptimizer(ABC):
         self.allreduce_position_embedding_grads(args)
     
     def allreduce_key_value_grads(self, args):
-        # TODO: models[0] ?
-        unwrapped_model = self.models[0]
-        unwrapped_model = unwrap_model(
-                unwrapped_model, (torchDDP, LocalDDP, Float16Module))
-        for layer in unwrapped_model.language_model.encoder.layers:
-            kv_weight = layer.self_attention.key_value.weight
-            if args.DDP_impl == 'local':
-                grad = kv_weight.main_grad
-            else:
-                grad = kv_weight.grad
-            torch.distributed.all_reduce(grad, group=mpu.get_tensor_model_parallel_group())
-
+        """
+        Reduce the gradients for the key_value weights and biases for multi-query attention.
+        Coalesce the bias grads to avoid too many small reductions,
+        but not the weight grads since it could cause memory issues.
+        """
+        grads=[]
+        for model_module in self.models:
+            unwrapped_model = unwrap_model(
+                    model_module, (torchDDP, LocalDDP, Float16Module))
+            for layer in unwrapped_model.language_model.encoder.layers:
+                kv_weight = layer.self_attention.key_value.weight
+                grad = kv_weight.main_grad if args.DDP_impl == 'local' else kv_weight.grad
+                torch.distributed.all_reduce(grad, group=mpu.get_tensor_model_parallel_group())
+                kv_bias = layer.self_attention.key_value.bias
+                grads.append(kv_bias.main_grad if args.DDP_impl == 'local' else kv_bias.grad)
+        if len(grads)>0:
+            coalesced = _flatten_dense_tensors(grads)
+            torch.distributed.all_reduce(
+                coalesced, group=mpu.get_tensor_model_parallel_group())
+            for buf, synced in zip(grads, _unflatten_dense_tensors(
+                    coalesced, grads)):
+                buf.copy_(synced)
 
     def allreduce_layernorm_grads(self, args):
         """All-reduce layernorm grads (for sequence parallelism)."""


### PR DESCRIPTION
Fixes #11 
* Add looping over interleaved stages
* Add reduction for the biases (coalesced, see docstring)
* Add reduction to the distributed optimizer
* Fix with sequence parallelism (not 100% sure about this but the crash is fixed)

Tested by checking that the weights remain the same across tensor-parallel ranks. Added in `train` method, after logging.
```
if iteration % args.log_interval == 0:
    for i,model_module in enumerate(model):
        unwrapped_model = unwrap_model(model_module, (torchDDP, LocalDDP, Float16Module))
        for j,layer in enumerate(unwrapped_model.language_model.encoder.layers):
            kv=layer.self_attention.key_value
            w=kv.weight.mean().cpu().item()
            b=kv.bias.mean().cpu().item()
            print(f"Rank {mpu.get_tensor_model_parallel_rank()}, model {i}, layer {j}, weight {w}, bias {b}")
```

* Test for bias, before fix:
```
Rank 0, model 0, layer 0, weight 3.552436828613281e-05, bias 7.241964340209961e-05
Rank 1, model 0, layer 0, weight 3.552436828613281e-05, bias -8.14199447631836e-05
```
* Test for bias, after fix:
```
Rank 0, model 0, layer 0, weight 3.552436828613281e-05, bias 2.86102294921875e-06
Rank 1, model 0, layer 0, weight 3.552436828613281e-05, bias 2.86102294921875e-06
```

* Dist optimizer, before fix:
```
Rank 1, model 0, layer 0, weight 3.8504600524902344e-05, bias -3.898143768310547e-05
Rank 0, model 0, layer 0, weight 3.49879264831543e-05, bias 4.869699478149414e-05

```
* Dist optimizer, after fix:
```
Rank 1, model 0, layer 0, weight 3.552436828613281e-05, bias 2.0325183868408203e-05
Rank 1, model 0, layer 0, weight 3.552436828613281e-05, bias 2.0325183868408203e-05
```

* Interleaved stages, before fix:
```
Rank 0, model 0, layer 0, weight 3.74913215637207e-05, bias -2.384185791015625e-05
Rank 0, model 1, layer 0, weight -0.0001628398895263672, bias 2.2470951080322266e-05
Rank 1, model 0, layer 0, weight 3.7729740142822266e-05, bias -7.772445678710938e-05
Rank 1, model 1, layer 0, weight -0.0001634359359741211, bias 2.855062484741211e-05
```
* Interleaved stages,  after fix:
```
Rank 0, model 0, layer 0, weight 3.409385681152344e-05, bias -7.170438766479492e-05
Rank 0, model 1, layer 0, weight -0.0001653432846069336, bias 0.0001214146614074707
Rank 1, model 0, layer 0, weight 3.409385681152344e-05, bias -7.170438766479492e-05
Rank 1, model 1, layer 0, weight -0.0001653432846069336, bias 0.0001214146614074707
```

