### PR TITLE
Structured logs and distributed timeout.

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -488,6 +488,10 @@ def _add_logging_args(parser):
     group.add_argument('--transformer-timers', action='store_true',
                         help="If set, activate the timers within the transformer layers."
                         "Only for debugging, as this slows down the model.")
+    group.add_argument('--structured-logs', action="store_true",
+                       help='Add timestamp and worker name to stdout and stderr.')
+    group.add_argument('--structured-logs-dir', type=str, default=None,
+                       help='Directory to save the logs.')
 
     return parser
 
@@ -836,6 +840,9 @@ def _add_distributed_args(parser):
                        'affects the encoder embedding.)')
     group.add_argument('--use-distributed-optimizer', action='store_true',
                        help='Use distributed optimizer.')
+    group.add_argument('--distributed-timeout', default=600, type=float,
+                       help='Timeout for distributed operations, in seconds. '
+                       'Should be at least as high as the dataset preprocessing ans checkpoint saving times.')
 
     return parser
 

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -15,6 +15,8 @@
 
 """Megatron initialization."""
 
+import logging
+import logging.config
 import random
 import os
 import time
@@ -74,6 +76,7 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
         args = get_args()
         # Pytorch distributed.
         _initialize_distributed()
+        _configure_logging()
         
         # Random seeds for reproducibility.
         if args.rank == 0:
@@ -102,6 +105,51 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
 
         # No continuation function
         return None
+
+
+def _configure_logging():
+    args=get_args()
+    if not args.structured_logs:
+        return
+    rank = torch.distributed.get_rank()
+
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": f"%(asctime)s [Rank {rank}]: %(message)s",
+                "use_colors": True,
+            }
+        },
+        "handlers": {
+            "default": {
+                "level": "INFO",
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "loggers": {"default": {"level": "DEBUG", "handlers": ["default"]}},
+        "root": {"handlers": ["default"], "level": "INFO"},
+    }
+    if args.structured_logs_dir is not None:
+        log_dir=args.structured_logs_dir
+        os.makedirs(log_dir, exist_ok=True)
+        logging_config["handlers"]["file"] = {
+            "level": "INFO",
+            "formatter": "default",
+            "class": "logging.FileHandler",
+            "filename": os.path.join(log_dir, f"logs_rank_{rank}.txt"),
+        }
+        logging_config["root"]["handlers"].append("file")
+        logging_config["loggers"]["default"]["handlers"].append("file")
+    logging.config.dictConfig(logging_config)
+
+    # Add these methods so that stdout can be redirected to logging.
+    logging.write = lambda msg: logging.info(msg) if msg != '\n' else None
+    logging.flush = lambda : None
+
 
 
 def _compile_dependencies():
@@ -191,11 +239,28 @@ def _initialize_distributed():
             torch.cuda.set_device(device)
         # Include this torch.distributed.init_process_group() code in the `else` branch because
         # we do not want to reinitialize if torch.distributed.is_initialized() returns True
+        if "AGENT_STORE_HOST" in os.environ:
+            # This allows creating the store on an external server.
+            # This is needed when the master host address is not known in advance.
+            # Does not handle torch elastic restarts.
+            store = torch.distributed.TCPStore(
+                host_name=os.environ["AGENT_STORE_HOST"],
+                port=int(os.environ["AGENT_STORE_PORT"]),
+                world_size=0,
+                is_master=False,
+                timeout=timedelta(seconds=float(os.environ["AGENT_STORE_TIMEOUT"]))
+                    if "AGENT_STORE_TIMEOUT" in os.environ else None,
+            )
+        else:
+            store=None
+
         # Call the init process
         torch.distributed.init_process_group(
             backend=args.distributed_backend,
             world_size=args.world_size, rank=args.rank,
-            timeout=timedelta(minutes=10))
+            timeout=timedelta(seconds=args.distributed_timeout),
+            store=store,
+        )
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -19,6 +19,7 @@ import logging
 import logging.config
 import random
 import os
+import sys
 import time
 
 import numpy as np
@@ -149,6 +150,9 @@ def _configure_logging():
     # Add these methods so that stdout can be redirected to logging.
     logging.write = lambda msg: logging.info(msg) if msg != '\n' else None
     logging.flush = lambda : None
+
+    sys.stdout=logging
+    sys.stderr=logging
 
 
 

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -243,28 +243,11 @@ def _initialize_distributed():
             torch.cuda.set_device(device)
         # Include this torch.distributed.init_process_group() code in the `else` branch because
         # we do not want to reinitialize if torch.distributed.is_initialized() returns True
-        if "AGENT_STORE_HOST" in os.environ:
-            # This allows creating the store on an external server.
-            # This is needed when the master host address is not known in advance.
-            # Does not handle torch elastic restarts.
-            store = torch.distributed.TCPStore(
-                host_name=os.environ["AGENT_STORE_HOST"],
-                port=int(os.environ["AGENT_STORE_PORT"]),
-                world_size=0,
-                is_master=False,
-                timeout=timedelta(seconds=float(os.environ["AGENT_STORE_TIMEOUT"]))
-                    if "AGENT_STORE_TIMEOUT" in os.environ else None,
-            )
-        else:
-            store=None
-
         # Call the init process
         torch.distributed.init_process_group(
             backend=args.distributed_backend,
             world_size=args.world_size, rank=args.rank,
-            timeout=timedelta(seconds=args.distributed_timeout),
-            store=store,
-        )
+            timeout=timedelta(seconds=args.distributed_timeout))
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.


### PR DESCRIPTION
* Add structured logging (timestamp and worker rank), essential for debugging.
* Add distributed timeout option. The timeout can be made much lower than the default to catch errors faster but is limited by the duration of dataset preprocessing, checkpoint saving and compilation of dependencies (if not done already).