### PR TITLE
We need to sync gradients with regards to input in MQA

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -614,6 +614,8 @@ class ParallelAttention(MegatronModule):
             if get_args().sequence_parallel:
                 # The linear layer doesn't gather the sequence-parallel.
                 kv_input = mpu.gather_from_sequence_parallel_region(kv_input, tensor_parallel_output_grad=False)
+            else:
+                kv_input = mpu.copy_to_tensor_model_parallel_region(kv_input)
             # Attention heads [sq, b, h] --> [sq, b, (2 * hn)]
             mixed_kv_layer = self.key_value(kv_input)
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -611,13 +611,15 @@ class ParallelAttention(MegatronModule):
              value_layer) = mpu.split_tensor_along_last_dim(mixed_x_layer, 3)
         elif self.attention_type == AttnType.self_attn and self.attention_head_type == 'multiquery':
             kv_input=hidden_states
-            if get_args().sequence_parallel:
-                # The linear layer doesn't gather the sequence-parallel.
-                kv_input = mpu.gather_from_sequence_parallel_region(kv_input, tensor_parallel_output_grad=False)
-            else:
-                kv_input = mpu.copy_to_tensor_model_parallel_region(kv_input)
+
             # Attention heads [sq, b, h] --> [sq, b, (2 * hn)]
             mixed_kv_layer = self.key_value(kv_input)
+
+            if get_args().sequence_parallel:
+                # The linear layer doesn't gather the sequence-parallel.
+                mixed_kv_layer = mpu.gather_from_sequence_parallel_region(kv_input, tensor_parallel_output_grad=True)
+            else:
+                mixed_kv_layer = mpu.copy_to_tensor_model_parallel_region(kv_input)
 
             # [sq, b, (2 * hn)] --> [sq, b, np (expanded), 2 * hn]
             # new_tensor_shape = mixed_kv_layer.size()[:-1] + \

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -617,9 +617,9 @@ class ParallelAttention(MegatronModule):
 
             if get_args().sequence_parallel:
                 # The linear layer doesn't gather the sequence-parallel.
-                mixed_kv_layer = mpu.gather_from_sequence_parallel_region(kv_input, tensor_parallel_output_grad=True)
+                mixed_kv_layer = mpu.gather_from_sequence_parallel_region(mixed_kv_layer, tensor_parallel_output_grad=True)
             else:
-                mixed_kv_layer = mpu.copy_to_tensor_model_parallel_region(kv_input)
+                mixed_kv_layer = mpu.copy_to_tensor_model_parallel_region(mixed_kv_layer)
 
             # [sq, b, (2 * hn)] --> [sq, b, np (expanded), 2 * hn]
             # new_tensor_shape = mixed_kv_layer.size()[:-1] + \

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -272,23 +272,27 @@ class MegatronOptimizer(ABC):
         Coalesce the bias grads to avoid too many small reductions,
         but not the weight grads since it could cause memory issues.
         """
-        grads=[]
-        for model_module in self.models:
-            unwrapped_model = unwrap_model(
-                    model_module, (torchDDP, LocalDDP, Float16Module))
-            for layer in unwrapped_model.language_model.encoder.layers:
-                kv_weight = layer.self_attention.key_value.weight
-                grad = kv_weight.main_grad if args.DDP_impl == 'local' else kv_weight.grad
-                torch.distributed.all_reduce(grad, group=mpu.get_tensor_model_parallel_group())
-                kv_bias = layer.self_attention.key_value.bias
-                grads.append(kv_bias.main_grad if args.DDP_impl == 'local' else kv_bias.grad)
-        if len(grads)>0:
-            coalesced = _flatten_dense_tensors(grads)
-            torch.distributed.all_reduce(
-                coalesced, group=mpu.get_tensor_model_parallel_group())
-            for buf, synced in zip(grads, _unflatten_dense_tensors(
-                    coalesced, grads)):
-                buf.copy_(synced)
+        # All-reduce kv parameters across model parallel nodes
+        # when sequence parallelism is used
+        if mpu.get_tensor_model_parallel_world_size() > 1 and \
+                args.sequence_parallel:
+            grads=[]
+            for model_module in self.models:
+                unwrapped_model = unwrap_model(
+                        model_module, (torchDDP, LocalDDP, Float16Module))
+                for layer in unwrapped_model.language_model.encoder.layers:
+                    kv_weight = layer.self_attention.key_value.weight
+                    grad = kv_weight.main_grad if args.DDP_impl == 'local' else kv_weight.grad
+                    torch.distributed.all_reduce(grad, group=mpu.get_tensor_model_parallel_group())
+                    kv_bias = layer.self_attention.key_value.bias
+                    grads.append(kv_bias.main_grad if args.DDP_impl == 'local' else kv_bias.grad)
+            if len(grads)>0:
+                coalesced = _flatten_dense_tensors(grads)
+                torch.distributed.all_reduce(
+                    coalesced, group=mpu.get_tensor_model_parallel_group())
+                for buf, synced in zip(grads, _unflatten_dense_tensors(
+                        coalesced, grads)):
+                    buf.copy_(synced)
 
     def allreduce_layernorm_grads(self, args):
         """All-reduce layernorm grads (for sequence parallelism)."""


### PR DESCRIPTION
Fixes: #35 

The issue is that in MQA we need to sync gradients with regards to weigths/bias as they are duplicated over TP. However we also need to synchronize gradient with regards to input, similarly to how it's done in ColumnLinear