### PR TITLE
Reduce the tensor-parallel KV output grads

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -617,6 +617,9 @@ class ParallelAttention(MegatronModule):
             # Attention heads [sq, b, h] --> [sq, b, (2 * hn)]
             mixed_kv_layer = self.key_value(kv_input)
 
+            # The KV output gradients include a sum over attn head so need an allreduce.
+            mixed_kv_layer = mpu.copy_to_tensor_model_parallel_region(mixed_kv_layer)
+
             # [sq, b, (2 * hn)] --> [sq, b, np (expanded), 2 * hn]
             # new_tensor_shape = mixed_kv_layer.size()[:-1] + \
             #     (self.num_attention_heads_per_partition,

--- a/megatron/optimizer/distrib_optimizer.py
+++ b/megatron/optimizer/distrib_optimizer.py
@@ -541,12 +541,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         self.allreduce_embedding_grads(args)
         timers('backward-embedding-all-reduce').stop()
 
-        # All-reduce key-value grads if needed.
-        if args.attention_head_type == "multiquery":
-            timers('backward-key-value-all-reduce').start()
-            self.allreduce_key_value_grads(args)
-            timers('backward-key-value-all-reduce').stop()
-
         # Reduce-scatter setup.
         timers('backward-params-all-reduce').start()
         data_parallel_rank = mpu.get_data_parallel_rank()

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -265,30 +265,7 @@ class MegatronOptimizer(ABC):
         """All-reduce both word and position embeddings."""
         self.allreduce_word_embedding_grads(args)
         self.allreduce_position_embedding_grads(args)
-    
-    def allreduce_key_value_grads(self, args):
-        """
-        Reduce the gradients for the key_value weights and biases for multi-query attention.
-        Coalesce the bias grads to avoid too many small reductions,
-        but not the weight grads since it could cause memory issues.
-        """
-        grads=[]
-        for model_module in self.models:
-            unwrapped_model = unwrap_model(
-                    model_module, (torchDDP, LocalDDP, Float16Module))
-            for layer in unwrapped_model.language_model.encoder.layers:
-                kv_weight = layer.self_attention.key_value.weight
-                grad = kv_weight.main_grad if args.DDP_impl == 'local' else kv_weight.grad
-                torch.distributed.all_reduce(grad, group=mpu.get_tensor_model_parallel_group())
-                kv_bias = layer.self_attention.key_value.bias
-                grads.append(kv_bias.main_grad if args.DDP_impl == 'local' else kv_bias.grad)
-        if len(grads)>0:
-            coalesced = _flatten_dense_tensors(grads)
-            torch.distributed.all_reduce(
-                coalesced, group=mpu.get_tensor_model_parallel_group())
-            for buf, synced in zip(grads, _unflatten_dense_tensors(
-                    coalesced, grads)):
-                buf.copy_(synced)
+
 
     def allreduce_layernorm_grads(self, args):
         """All-reduce layernorm grads (for sequence parallelism)."""
@@ -332,13 +309,6 @@ class MegatronOptimizer(ABC):
         timers('backward-embedding-all-reduce').start()
         self.allreduce_embedding_grads(args)
         timers('backward-embedding-all-reduce').stop()
-
-        # All-reduce key-value grads if needed.
-        if args.attention_head_type == "multiquery":
-            timers('backward-key-value-all-reduce').start()
-            self.allreduce_key_value_grads(args)
-            timers('backward-key-value-all-reduce').stop()
-
 
 
 class MixedPrecisionOptimizer(MegatronOptimizer):


### PR DESCRIPTION
Edit: the new version of #36 should be better than this.
Alternative to #36
Fix the kv gradient computation in tensor-parallel.
Add a reduction in the kv output grads and remove the kv parameter grad reduction.

Compared to #36, this is faster and more closely matches the mathematical justification, which comes from the Q x K multiplication:
```
A [batch, num_heads * sq, sk] = Q [batch, num_heads * sq, head_size] x K^T [batch, head_size, sk]
G_K [batch, head_size, sk] = Q^T [batch, head_size, num_heads * sq] x G_A [batch, num_heads * sq, sk]
```
The sum over num_heads is where we need the reduction.

Valid loss after 5000 steps, runtime /  average step time for a small model:
```
Method                            Loss        Runtime     Avg
MHA:                              2.604475    2820 s      564 ms
MQA, TP=1:                        2.641582    2303 s      461 ms 
MQA, before fix:                  3.740988    2538 s      508 ms
MQA, after this fix:              2.640481    2528 s      506 ms
MQA, with PR 36, v1:              2.640432    2602 s      520 ms
MQA, with PR 36, v2               2.640481    2548 s      510 ms
MQA, sequence parallel:           2.640036    2654 s      531 ms
MQA, sequence parallel, PR 36 v2: 2.638824    2629 s      526 ms
```
So both implementations work and are almost identical, but this PR is faster (difference would be smaller in real scenario because this is a very small model with a huge TP overhead.).