### PR TITLE
convert reshape to view

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -279,8 +279,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
         # https://github.com/pytorch/pytorch/blob/c47cf9bc7f9e02f649ab4ed53fe4d35732c92ab6/torch/_refs/__init__.py#L2761
         grad_output = grad_output.contiguous()
         # Convert the tensor shapes to 2D for execution compatibility
-        # TODO: Is the reshape preventing us from getting a speedup here?
-        grad_output = grad_output.reshape(grad_output.shape[0] * grad_output.shape[1],
+        grad_output = grad_output.view(grad_output.shape[0] * grad_output.shape[1],
                                        grad_output.shape[2])
         total_input = total_input.view(total_input.shape[0] * total_input.shape[1],
 				       total_input.shape[2])


### PR DESCRIPTION
Is this needed anymore?
I tried running for 100 steps and I get the same lm loss with both.